### PR TITLE
add GBP to MOP currency conversion

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -266,6 +266,8 @@ function displayForecast(city) {
               currency = 'THB';
             } else if (countryCode == 'AE') {
               currency = 'AED';
+            } else if (countryCode == 'MO') {
+              currency = 'MOP';
             }
 
             if (currency) {


### PR DESCRIPTION
Currency conversion for Macau, one of the top destinations.